### PR TITLE
Updated network layer dependency to support new openConnection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pt.unl.fct.di.novasys</groupId>
     <artifactId>babel-core</artifactId>
-    <version>0.5.01</version>
+    <version>0.5.02</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.github.pfouto</groupId>
             <artifactId>network-layer</artifactId>
-            <version>2.0.42</version>
+            <version>2.0.43</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/pt/unl/fct/di/novasys/babel/channels/multi/MultiChannel.java
+++ b/src/main/java/pt/unl/fct/di/novasys/babel/channels/multi/MultiChannel.java
@@ -172,7 +172,7 @@ public class MultiChannel extends SingleThreadedBiChannel<BabelMessage, BabelMes
     }
 
     @Override
-    protected void onOpenConnection(Host host) {
+    protected void onOpenConnection(Host host, int connection) {
         throw new NotImplementedException("Pls fix me");
     }
 

--- a/src/main/java/pt/unl/fct/di/novasys/babel/core/Babel.java
+++ b/src/main/java/pt/unl/fct/di/novasys/babel/core/Babel.java
@@ -261,12 +261,12 @@ public class Babel {
      * Opens a connection to a peer in the given channel.
      * Called by {@link GenericProtocol}. Do not evoke directly.
      */
-    void openConnection(int channelId, Host target) {
+    void openConnection(int channelId, Host target, int connection) {
         Triple<IChannel<BabelMessage>, ChannelToProtoForwarder, BabelMessageSerializer> channelEntry =
                 channelMap.get(channelId);
         if (channelEntry == null)
             throw new AssertionError("Opening connection in non-existing channelId " + channelId);
-        channelEntry.getLeft().openConnection(target);
+        channelEntry.getLeft().openConnection(target, connection);
     }
 
     /**

--- a/src/main/java/pt/unl/fct/di/novasys/babel/core/GenericProtocol.java
+++ b/src/main/java/pt/unl/fct/di/novasys/babel/core/GenericProtocol.java
@@ -438,7 +438,7 @@ public abstract class GenericProtocol {
      * @param channelId the channel to create the connection in
      */
     protected final void openConnection(Host peer, int channelId) {
-        babel.openConnection(channelId, peer);
+        babel.openConnection(channelId, peer, protoId);
     }
 
     /**


### PR DESCRIPTION
Updated network-layer dependency version (`2.0.43`) in order to support changes in channel's openConnection method which now receives a connection identifier. GenericProtocol class defines the connection identifier as the Babel protocol id.

No changes were made in the API exposed by the GenericProtocol class.